### PR TITLE
Make a terminals page, split terminals component into two so its more…

### DIFF
--- a/frontend/src/components/MicroTerminal/MicroTerminal.js
+++ b/frontend/src/components/MicroTerminal/MicroTerminal.js
@@ -1,0 +1,99 @@
+import React, { useEffect, useRef } from 'react';
+import { useXTerm } from 'react-xtermjs';
+import '@xterm/xterm/css/xterm.css';
+
+export default function MicroTerminal() {
+    const { instance, ref } = useXTerm({
+        cursorBlink: true,
+        fontSize: 14,
+        fontFamily: 'monospace',
+        theme: {
+            background: '#1e1e1e',
+            foreground: '#00ff00',
+            cursor: '#00ff00',
+        },
+    });
+    const input = useRef('');
+    const ws = useRef(null);
+
+    useEffect(() => {
+        if (!instance) { return; }
+
+         // Connect to backend WebSocket
+        ws.current = new WebSocket('ws://localhost:9090/micro');
+        ws.current.onopen = () => {
+            instance.writeln('> Connected to Java backend.\r\n');
+        };
+
+        ws.current.onmessage = (event) => {
+            // Data from backend (shell output)
+            instance.write(event.data);
+        };
+
+        ws.current.onclose = () => {
+            instance.writeln('\r\n> Connection closed.');
+        };
+
+        ws.current.onerror = (err) => {
+            console.error('WebSocket error:', err);
+            instance.writeln('\r\n> Connection error.');
+        };
+
+        // focus terminal so user can type
+        instance.focus();
+
+        instance.writeln('> Welcome to JavaBeans! Start learning :)');
+        instance.write('> ');
+
+        const handleCommand = (command) => {
+            if (command.toLowerCase() === 'hello') {
+                instance.writeln('Hello back!');
+            } else if(command.toLowerCase() === 'clear') {
+                instance.clear();
+            } else {
+                instance.writeln(`Unknown command: ${command}`);
+            }
+        };
+
+        const dispose = instance.onData((data) => {
+            ws.current?.send(data);
+            // if user pressed enter, 13, move to a new line
+            if (data.charCodeAt(0) === 13) {
+                instance.writeln('');
+                handleCommand(input.current);
+                // clears the terminal once user types "clear"
+                input.current = '';
+                instance.write('> ');
+            } else if (data.charCodeAt(0) == 127) {
+                if (input.current.length > 0) {
+                    instance.write('\b \b');
+                    // erase character in buffer
+                    input.current = input.current.slice(0, -1);
+                }
+            } else {
+                instance.write(data);
+                input.current += data;
+            }
+        });
+
+        return () => {
+            dispose.dispose();
+            instance.dispose();
+        };
+    }, [instance]);
+
+    return (
+        <div
+            ref={ref}
+            tabIndex={0}
+            style={{
+                width: '80%',
+                height: '400px',
+                backgroundColor: '#1e1e1e',
+                borderRadius: '8px',
+                padding: '8px',
+                margin: '0 auto',
+            }}
+        />
+    );
+}

--- a/frontend/src/components/TestTerminal/TestTerminal.js
+++ b/frontend/src/components/TestTerminal/TestTerminal.js
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import { useXTerm } from 'react-xtermjs';
 import '@xterm/xterm/css/xterm.css';
 
-export default function MicroTerminal() {
+export default function TestTerminal() {
     const { instance, ref } = useXTerm({
         cursorBlink: true,
         fontSize: 14,
@@ -20,9 +20,9 @@ export default function MicroTerminal() {
         if (!instance) { return; }
 
          // Connect to backend WebSocket
-        ws.current = new WebSocket('ws://localhost:9090/');
+        ws.current = new WebSocket('ws://localhost:9090/test');
         ws.current.onopen = () => {
-            instance.writeln('Connected to Java backend.\r\n');
+            instance.writeln('> Connected to Java backend.\r\n');
         };
 
         ws.current.onmessage = (event) => {
@@ -31,18 +31,18 @@ export default function MicroTerminal() {
         };
 
         ws.current.onclose = () => {
-            instance.writeln('\r\nConnection closed.');
+            instance.writeln('\r\n> Connection closed.');
         };
 
         ws.current.onerror = (err) => {
             console.error('WebSocket error:', err);
-            instance.writeln('\r\nConnection error.');
+            instance.writeln('\r\n> Connection error.');
         };
 
         // focus terminal so user can type
         instance.focus();
 
-        instance.writeln('> Welcome to JavaBeans! Start learning :)');
+        instance.writeln('> Welcome to JavaBeans! This terminal is for testing only.');
         instance.write('> ');
 
         const handleCommand = (command) => {

--- a/frontend/src/pages/App/App.js
+++ b/frontend/src/pages/App/App.js
@@ -1,7 +1,6 @@
 import { BrowserRouter, Routes, Route} from 'react-router-dom';
 import './App.css';
 import NavBar from '../../components/NavBar/NavBar';
-import MicroTerminal from '../../components/Terminals/MicroTerminal';
 import Home from '../Home/Home';
 import About from '../About/About';
 import Faq from '../Faq/Faq';

--- a/frontend/src/pages/Home/Home.js
+++ b/frontend/src/pages/Home/Home.js
@@ -1,9 +1,9 @@
-import MicroTerminal from '../../components/Terminals/MicroTerminal';
+import Terminals from '../Terminals/Terminals';
 
 export default function Home() {
 	return (
 		<div>
-			<MicroTerminal />
+			<Terminals />
 		</div>
 	);
 }

--- a/frontend/src/pages/Terminals/Terminals.js
+++ b/frontend/src/pages/Terminals/Terminals.js
@@ -1,0 +1,13 @@
+import MicroTerminal from '../../components/MicroTerminal/MicroTerminal';
+import TestTerminal from '../../components/TestTerminal/TestTerminal';
+
+export default function Terminals() {
+  return (
+    <div>
+      <h2>Micro Terminal</h2>
+      <MicroTerminal />
+      <h2>Testing Terminal</h2>
+      <TestTerminal />
+    </div>
+  );
+}


### PR DESCRIPTION
- Instead of a terminals component directory, i split it into two for organization:
   - microterminal: terminal for micro
      - Websocket url: (ws://localhost:9090/micro)
   -  testterminal: terminal for testing
      - Websocket url: (ws://localhost:9090/test)
- i edited some of the imports so that it doesn't break the code
- made a terminals page where both terminals can be stored there so i can put insert it into the home class